### PR TITLE
fix: map bunyan "msg" to "message" to work with default logzio config

### DIFF
--- a/lib/logzio-bunyan.js
+++ b/lib/logzio-bunyan.js
@@ -37,6 +37,13 @@ LogzioLogger.prototype.write = function (msg) {
     else if (typeof msg === 'string') {
         msg = {message: msg};
     }
+    // make a copy so we don't mess up other loggers
+    msg = _assign({}, msg)
+
+    if (msg.hasOwnProperty('msg')) {
+        msg.message = msg.msg;
+        delete msg.msg;
+    }
 
     var level = this.level;
     if (msg.hasOwnProperty('level') && levels.hasOwnProperty(msg.level)) {
@@ -52,3 +59,4 @@ LogzioLogger.prototype.write = function (msg) {
 };
 
 exports = module.exports = LogzioLogger;
+


### PR DESCRIPTION
when migrating to logz I noticed that my messages were not showing up in Kibana by default. It was showing under the "msg" attribute while it seems like Kibana is configured to look for "message". This changes the default so that it will be mapped correctly.