### PR TITLE
Close underlying stream properly

### DIFF
--- a/lib/logzio-bunyan.js
+++ b/lib/logzio-bunyan.js
@@ -8,7 +8,9 @@ function LogzioLogger(options) {
 
     this.logzioLogger = logzioNodejs.createLogger(options);
 
-    this.end = function () {  };
+	this.end = function () {
+		this.logzioLogger.close();
+	};
 }
 
 var levels = {

--- a/lib/logzio-bunyan.js
+++ b/lib/logzio-bunyan.js
@@ -8,9 +8,9 @@ function LogzioLogger(options) {
 
     this.logzioLogger = logzioNodejs.createLogger(options);
 
-	this.end = function () {
-		this.logzioLogger.close();
-	};
+    this.end = function () {
+        this.logzioLogger.close();
+    };
 }
 
 var levels = {


### PR DESCRIPTION
When running a console application using `logzio-bunyan` the application blocks at the end and never exits.
It does so because the underlying `logzio-nodejs` package uses a timer internally and that's a resource that has to be cleaned up properly.

This can be done quite easily as seen in the PR.